### PR TITLE
Add support for minor mode and commands keymap.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,38 +10,64 @@ Add it to your Emacs' `load-path`:
 
 `(add-to-list load-path '/path/to/emacs-npm/')`
 
-# Usage
+Enable the mode globally:
 
-# Opening your `package.json`
+`(emacsnpm-global-mode)`
 
-From anywhere inside a directory which contains a `package.json` run the following command:
+## Commands
 
-#### `emacsnpm-open-package`
+### `emacsnpm-global-mode`
 
-# Running npm-init 
-From anywhere inside a directory in which you wish to initialise npm run the following command:
+Running <kbd>M-x emacsnpm-global-mode</kbd> creates keybindings to the
+various emacsnpm commands. The keymap prefix is `C-c n` by default and can be
+changed with <kbd>M-x customize-variable emacsnpm-keymap-prefix</kbd>.
 
-#### `emacsnpm-init`
+| command               | Keymap       | Description                  |
+|-----------------------|--------------|------------------------------|
+| emacsnpm-init         | <kbd>n</kbd> | Initialize new package.json  |
+| emacsnpm-open-package | <kbd>e</kbd> | Edit package.json            |
+| emacsnpm-install      | <kbd>i</kbd> | Install dependencies         |
+| emacsnpm-exec         | <kbd>r</kbd> | Run script                   |
+| emacsnpm-save         | <kbd>s</kbd> | Install dependency           |
+| emacsnpm-save-dev     | <kbd>d</kbd> | Install dev dependency       |
+| emacsnpm-uninstall    | <kbd>u</kbd> | Uninstall project package    |
+|                       | <kbd>?</kbd> | Display keymap commands      |
 
-This will open the `package.json` contained in your directory
+You can also call the commands directly.
 
-# Running npm commands
-From anywhere inside a directory that contains a `package.json` run the following command:
+### `emacsnpm-init`
 
-#### `emacsnpm-exec`
+Running <kbd>C-c n n</kbd> will create a new npm project in the current directory.
 
-This will provide you with a list of possible commands which are populated from the script object in the `package.json`.
+### `emacsnpm-open-package`
 
-# Saving npm dependencies
-From anywhere inside a directory that contains a `package.json` run the following command:
+Running <kbd>C-c n e</kbd> in an npm project directory will open the project 
+package.json file in a buffer for editing
+
+### `emacsnpm-install`
+
+Running <kbd>C-c n i</kbd> in an npm project directory will install the project
+dependencies.
+
+### `emacsnpm-exec`
+
+Running <kbd>C-c n r</kbd> in an npm project directory will prompt for the
+name of a script to run and will run it. Completion support is provided.
 
 #### `emacsnpm-save`
 
-This will run prompt you for the name of a package and run `npm install --save` for that package
+Running <kbd>C-c n s</kbd> in an npm project directory will prompt for the
+name of a package to install and install it as a project dependency.
 
 #### `emacsnpm-save-dev`
 
-This will run prompt you for the name of a package and run `npm install --save-dev` for that package
+Running <kbd>C-c n s</kbd> in an npm project directory will prompt for the
+name of a package to install and install it as a project dev dependency.
+
+#### `emacsnpm-uninstall`
+
+Running <kbd>C-c n s</kbd> in an npm project directory will prompt for the
+name of a package to uninstall and uninstall it as a project dependency.
 
 # TODO 
 

--- a/emacsnpm.el
+++ b/emacsnpm.el
@@ -132,5 +132,44 @@ http://www.emacswiki.org/emacs/EmacsTags#tags"
   (ansi-term (getenv "SHELL") "emacsnpm-save-dev")
   (comint-send-string "*emacsnpm-save-dev*" (format "npm install %s --save-dev\n" dependency)))
 
+(defgroup emacsnpm nil
+  "Customization group for `emacsnpm'."
+  :group 'convenience)
+
+(defcustom emacsnpm-keymap-prefix "C-c n"
+  "Prefix for `emacsnpm'."
+  :group 'emacsnpm)
+
+(defvar emacsnpm-command-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map "n" 'emacsnpm-init)	         ; mnemonic 'new'
+    (define-key map "e" 'emacsnpm-open-package)	 ; mnemonic 'edit'
+    (define-key map "i" 'emacsnpm-install)       ; mnemonic 'install'
+    (define-key map "r" 'emacsnpm-exec)		 ; mnemonic 'run'
+    (define-key map "s" 'emacsnpm-save)		 ; mnemonic same as npm -S opt
+    (define-key map "d" 'emacsnpm-save-dev)	 ; mnemonic same as npm -D opt
+    (define-key map "u" 'emacsnpm-uninstall)	 ; mnemonic 'uninstall'
+    map)
+  "Keymap for `emacsnpm' commands.")
+
+(defvar emacsnpm-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd emacsnpm-keymap-prefix) emacsnpm-command-map)
+    map)
+  "Keymap for `emacsnpm'.")
+
+;;;###autoload
+(define-minor-mode emacsnpm-mode
+  "Minor mode for integration with npm."
+  nil
+  " npm"
+  emacsnpm-mode-map
+  :group 'docker)
+
+;;;###autoload
+(define-globalized-minor-mode emacsnpm-global-mode
+  emacsnpm-mode
+  emacsnpm-mode)
+
 (provide 'emacsnpm)
 ;;; emacsnpm.el ends here


### PR DESCRIPTION
Hey Alex, I found your emacsnpm.el package useful so I extended it to a minor mode and gave it a command key map.  It has made interactive use better for me, and I thought others might find it useful.

I'd like to help with getting this package ready for MELPA next.  Any particular reason for the package name emacsnpm?  I know a package 'npm.el' exists, but it looks like its purpose is different from your package, and this change effectively turns your library into a minor mode.  Would you have any objection to staking out the 'npm-mode' package name?  It's short, available, indicates its mode nature, and is free of the redundant 'emacs' in the package name.  

Just a thought, but if you like the idea, changing it before publishing to MELPA would be a good thing.  Oh, and if you don't like the idea of a minor mode at all, that's cool, just let me know.

Cheers!